### PR TITLE
Add preprocessor directives for Win32 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,9 @@ project(davp-baseline)
 include_directories("$ENV{HOME}/libs/include")
 link_directories("$ENV{HOME}/libs/lib")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+if(CMAKE_COMPILER_IS_GNUCXX)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+endif(CMAKE_COMPILER_IS_GNUCXX)
 set(CMAKE_CXX_STANDARD 11)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules" "$ENV{HOME}/libs/lib")

--- a/CMakeListsWindows.txt
+++ b/CMakeListsWindows.txt
@@ -1,0 +1,133 @@
+cmake_minimum_required(VERSION 3.10.2)
+project(ssp)
+
+include_directories("$ENV{HOME}/libs/include" "C://Users//Andre//source//repos//vcpkg//installed//x64-windows//include")
+link_directories("$ENV{HOME}/libs/lib" "C://Users//Andre//source//repos//vcpkg//installed//x64-windows//lib")
+
+if(CMAKE_COMPILER_IS_GNUCXX)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+endif(CMAKE_COMPILER_IS_GNUCXX)
+set(CMAKE_CXX_STANDARD 11)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules" "$ENV{HOME}/libs/lib")
+list(APPEND CMAKE_PREFIX_PATH "$ENV{HOME}/libs/lib")
+
+find_package(Threads REQUIRED)
+find_package(OpenCV REQUIRED)
+find_package(FFmpeg REQUIRED)
+find_package(ZeroMQ)
+find_package(cppzmq)
+find_package(yaml-cpp)
+find_package(spdlog)
+find_package(k4a CONFIG REQUIRED)
+find_package(k4arecord CONFIG REQUIRED)
+
+
+find_path( AVCODEC_INCLUDE_DIR libavcodec/avcodec.h )
+find_library( AVCODEC_LIBRARY swscale )
+
+
+if (FFMPEG_FOUND)
+    #  FFMPEG_INCLUDE_DIRS  - Include directory necessary for using the required components headers.
+    #  FFMPEG_LIBRARIES     - Link these to use the required ffmpeg components.
+    #  FFMPEG_DEFINITIONS   - Compiler switches required for using the required ffmpeg components.
+    message("FFMPEG_INCLUDE_DIRS = ${FFMPEG_INCLUDE_DIRS} ")
+    message("FFMPEG_LIBRARIES = ${FFMPEG_LIBRARIES} ")
+    message("FFMPEG_DEFINITIONS = ${FFMPEG_DEFINITIONS} ")
+endif ()
+
+set(EXECUTABLE_OUTPUT_PATH bin)
+
+option(SSP_WITH_KINECT_SUPPORT "This is settable from the command line" ON)
+option(SSP_WITH_K4A_BODYTRACK "This is settable from the command line" ON)
+option(SSP_WITH_NVPIPE_SUPPORT "This is settable from the command line" OFF)
+
+if (SSP_WITH_NVPIPE_SUPPORT)
+    add_definitions(-DSSP_WITH_NVPIPE_SUPPORT=1)
+endif ()
+
+if (SSP_WITH_KINECT_SUPPORT)
+    add_definitions(-DSSP_WITH_KINECT_SUPPORT=1)
+endif ()
+
+if (SSP_WITH_K4A_BODYTRACK)
+    add_definitions(-DSSP_WITH_K4A_BODYTRACK=1)
+endif ()
+
+
+set(SOURCE_FILES readers/image_reader.cc readers/multi_image_reader.cc structs/frame_struct.hpp utils/utils.cc utils/video_utils.cc utils/image_decoder.cc utils/image_converter.cc)
+set(DECODER_SOURCE_FILES decoders/libav_decoder.cc decoders/zdepth_decoder.cc)
+set(ENCODER_SOURCE_FILES encoders/zdepth_encoder.cc encoders/null_encoder.cc encoders/libav_encoder.cc)
+set(READER_SOURCE_FILES readers/video_file_reader.cc readers/image_reader.cc)
+
+set(KINECT_READER_SOURCE_FILES readers/kinect_reader.cc utils/kinect_utils.cc)
+set(NVPIPE_ENCODER_SOURCE_FILES encoders/nv_encoder.cc)
+set(NVPIPE_DECODER_SOURCE_FILES decoders/nv_decoder.cc)
+
+if (SSP_WITH_NVPIPE_SUPPORT)
+    set(DECODER_SOURCE_FILES ${DECODER_SOURCE_FILES} ${NVPIPE_DECODER_SOURCE_FILES})
+    set(ENCODER_SOURCE_FILES ${ENCODER_SOURCE_FILES} ${NVPIPE_ENCODER_SOURCE_FILES})
+endif ()
+
+if (SSP_WITH_KINECT_SUPPORT)
+    set(READER_SOURCE_FILES ${READER_SOURCE_FILES} readers/kinect_reader.cc utils/kinect_utils.cc)
+    set(CLIENT_EXTRA_SOURCE_FILES ${CLIENT_EXTRA_SOURCE_FILES} utils/kinect_utils.cc)
+endif ()
+
+add_executable(ssp_client_opencv clients/ssp_client_opencv.cc readers/network_reader.cc ${DECODER_SOURCE_FILES} ${SOURCE_FILES} ${CLIENT_SOURCE_FILES})
+add_executable(ssp_client_template clients/ssp_client_template.cc readers/network_reader.cc ${DECODER_SOURCE_FILES} ${SOURCE_FILES} ${CLIENT_SOURCE_FILES})
+add_executable(ssp_server servers/ssp_server.cc ${READER_SOURCE_FILES} ${DECODER_SOURCE_FILES} ${ENCODER_SOURCE_FILES} ${SOURCE_FILES})
+add_executable(ssp_tester testers/ssp_tester.cc utils/similarity_measures.cc ${READER_SOURCE_FILES} ${DECODER_SOURCE_FILES} ${ENCODER_SOURCE_FILES} ${SOURCE_FILES})
+
+set(LIB_FILES libzmq zdepth zstd yaml-cpp spdlog::spdlog_header_only swscale)
+set(NVPIPE_LIB_FILES NvPipe)
+set(KINECT_LIB_FILES k4a k4arecord)
+set(K4A_BODYTRACK_LIB_FILES k4abt)
+
+target_link_libraries(ssp_client_opencv ${LIB_FILES})
+target_link_libraries(ssp_client_opencv ${FFMPEG_LIBRARIES})
+target_link_libraries(ssp_client_opencv ${OpenCV_LIBS})
+
+target_link_libraries(ssp_client_template ${LIB_FILES})
+target_link_libraries(ssp_client_template ${FFMPEG_LIBRARIES})
+target_link_libraries(ssp_client_template ${OpenCV_LIBS})
+
+target_link_libraries(ssp_server ${LIB_FILES})
+target_link_libraries(ssp_server ${FFMPEG_LIBRARIES})
+target_link_libraries(ssp_server ${OpenCV_LIBS})
+
+target_link_libraries(ssp_tester ${LIB_FILES})
+target_link_libraries(ssp_tester ${FFMPEG_LIBRARIES})
+target_link_libraries(ssp_tester ${OpenCV_LIBS})
+
+if (SSP_WITH_NVPIPE_SUPPORT)
+    target_link_libraries(ssp_client_opencv ${NVPIPE_LIB_FILES})
+    target_link_libraries(ssp_client_template ${NVPIPE_LIB_FILES})
+    target_link_libraries(ssp_server ${NVPIPE_LIB_FILES})
+    target_link_libraries(ssp_tester ${NVPIPE_LIB_FILES})
+endif ()
+
+if (SSP_WITH_KINECT_SUPPORT)
+    target_link_libraries(ssp_server ${KINECT_LIB_FILES})
+    target_link_libraries(ssp_tester ${KINECT_LIB_FILES})
+endif ()
+
+if (SSP_WITH_K4A_BODYTRACK)
+    add_executable(ssp_client_k4a clients/ssp_client_k4a.cc utils/kinect_utils.cc readers/network_reader.cc ${DECODER_SOURCE_FILES} ${SOURCE_FILES} ${CLIENT_SOURCE_FILES})
+    add_executable(ssp_client_pointcloud clients/ssp_client_pointcloud.cc utils/kinect_utils.cc readers/network_reader.cc ${DECODER_SOURCE_FILES} ${SOURCE_FILES} ${CLIENT_SOURCE_FILES})
+    if (SSP_WITH_NVPIPE_SUPPORT)
+        target_link_libraries(ssp_client_k4a ${NVPIPE_LIB_FILES})
+        target_link_libraries(ssp_client_pointcloud ${NVPIPE_LIB_FILES})
+    endif ()
+    target_link_libraries(ssp_client_k4a ${LIB_FILES})
+    target_link_libraries(ssp_client_k4a ${FFMPEG_LIBRARIES})
+    target_link_libraries(ssp_client_k4a ${OpenCV_LIBS})
+    target_link_libraries(ssp_client_k4a ${KINECT_LIB_FILES})
+    target_link_libraries(ssp_client_k4a ${K4A_BODYTRACK_LIB_FILES})
+
+    target_link_libraries(ssp_client_pointcloud ${LIB_FILES})
+    target_link_libraries(ssp_client_pointcloud ${FFMPEG_LIBRARIES})
+    target_link_libraries(ssp_client_pointcloud ${OpenCV_LIBS})
+    target_link_libraries(ssp_client_pointcloud ${KINECT_LIB_FILES})
+    target_link_libraries(ssp_client_pointcloud ${K4A_BODYTRACK_LIB_FILES})
+endif ()

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,6 +2,7 @@
 
 
 [Linux instructions](#linux)
+
 [Windows instructions](#windows)
 
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,12 +1,19 @@
 # Sensor Stream Pipe Instalation
 
+
+[Linux instructions](#linux)
+[Windows instructions](#windows)
+
+
+## Linux
+
 To get our Sensor Stream Pipe up and running, you will require the following:
 
 The following steps were tested on Ubuntu 18.04. Installing on other recent Linux distributions should be pretty similar, but please check the installation instructions for OpenCV and Kinect DK on your respective platform first. 
 Installation instructions for Windows should be ready soon.
 If you encounter any problems or have any suggestions, please let us know by emailing contact@moetsi.com or post on our [forum](https://moetsi.com/pages/community).
 
-## Dependencies
+### Dependencies
 
 To get our Sensor Stream Pipe up and running, you will require the following:
 
@@ -21,20 +28,20 @@ To get our Sensor Stream Pipe up and running, you will require the following:
 * [Azure Kinect SDK](https://github.com/microsoft/Azure-Kinect-Sensor-SDK/) 1.2 (*optional*) accesses Kinect DK data.
 * [Azure Kinect Body Tracking SDK](https://docs.microsoft.com/bs-cyrl-ba/azure/Kinect-dk/body-sdk-download/) 0.9.3 (*optional*) SSP Body Tracking client.
 
-## Download and install repo libraries
+### Download and install repo libraries
 
-### OpenCV 3.2.0
+#### OpenCV 3.2.0
 
 ```
 sudo apt install libopencv-dev libopencv-core-dev uuid-dev
 ```
-### Libav 3.4.6
+#### Libav 3.4.6
 
 ```
 sudo apt install libavformat-dev libavutil-dev libavcodec-dev libavfilter-dev
 ```
 
-## Download and extract "out-of-repo" libraries
+### Download and extract "out-of-repo" libraries
 
 
 First, create a folder where local libs are to be installed:
@@ -44,7 +51,7 @@ mkdir ~/libs
 mkdir ~/libs/srcOriginal
 ```
 
-### Cereal 1.2.2
+#### Cereal 1.2.2
 
 ```
 cd ~/libs/srcOriginal
@@ -53,10 +60,10 @@ tar xf v1.2.2
 cp -r cereal-1.2.2/include ~/libs
 ```
 
-### ZeroMQ
+#### ZeroMQ
 
 
-#### libzmq3 4.3.1
+##### libzmq3 4.3.1
 
 ```
 cd ~/libs/srcOriginal
@@ -69,7 +76,7 @@ cmake .. -DCMAKE_INSTALL_PREFIX=~/libs
 make install -j4
 ```
 
-#### cppzmq 4.3.0
+##### cppzmq 4.3.0
 
 ```
 cd ~/libs/srcOriginal
@@ -79,7 +86,7 @@ cd cppzmq-4.3.0
 cp *.hpp ~/libs/include
 ```
 
-### yaml-cpp 0.6.0
+#### yaml-cpp 0.6.0
 
 ```
 cd ~/libs/srcOriginal
@@ -92,7 +99,7 @@ cmake .. -DCMAKE_INSTALL_PREFIX=~/libs
 make install
 ```
 
-### Zdepth
+#### Zdepth
 
 ```
 cd ~/libs/srcOriginal
@@ -106,7 +113,7 @@ cp libzdepth.a ~/libs/lib/
 cp zstd/libzstd.a ~/libs/lib/
 ```
 
-### spdlog
+#### spdlog
 
 ```
 cd ~/libs/srcOriginal
@@ -118,7 +125,7 @@ make -j
 make install
 ```
 
-#### NVPipe (optional, recommended for users with Nvidia GPU)
+##### NVPipe (optional, recommended for users with Nvidia GPU)
 
 ```
 cd ~/libs/srcOriginal
@@ -130,7 +137,7 @@ make
 make install
 ```
 
-#### Azure Kinect SDK 1.2 (optional)
+##### Azure Kinect SDK 1.2 (optional)
 
 *Note: to avoid getting a password prompt, run any command as sudo before starting this section of the tutorial*
 
@@ -159,7 +166,7 @@ You can create it by running the following command:
 sudo ln -s /usr/lib/x86_64-linux-gnu/libdepthengine.so.2.0 /usr/lib/x86_64-linux-gnu/libdepthengine.so
 ```
 
-#### Azure Kinect Body Tracking SDK (optional)
+##### Azure Kinect Body Tracking SDK (optional)
 
 Check instructions above to add the Linux Software Repository for Microsoft Products and then do:
 
@@ -169,7 +176,7 @@ sudo apt install libk4abt0.9-dev
 ```
 
 
-### Building Sensor Stream Pipe
+#### Building Sensor Stream Pipe
 
 Download and build the project (the ssp_server, ssp_client and ssp_tester):
 
@@ -190,3 +197,79 @@ You can turn on Kinect, Bodytrack and NVPipe support by adding the following to 
 -DSSP_WITH_K4A_BODYTRACK=ON
 -DSSP_WITH_NVPIPE_SUPPORT=ON
 ```
+
+
+## Windows
+
+
+Windows installation process was performed using [vcpkg](https://docs.microsoft.com/en-us/cpp/build/vcpkg?view=msvc-160) to install most dependencies.
+Tested on Windows 10 Build 19041, Visual Studio 2019 Community Edition (VS).
+
+This process may also work for Linux, but this was not tested.
+
+### Install vcpkg
+
+Follow vcpkg installation instructions available [here](https://docs.microsoft.com/en-us/cpp/build/install-vcpkg?view=msvc-160&tabs=windows)
+
+### Install dependencies available on vcpkg
+
+Install dependencies using vcpkg.
+
+```
+vcpkg install azure-kinect-sensor-sdk:x64-windows cereal:x64-windows cppzmq:x64-windows ffmpeg:x64-windows opencv3:x64-windows spdlog:x64-windows yaml-cpp:x64-windows zeromq:x64-windows
+```
+
+### Build and install remaining dependecies 
+
+Prepare a directory to place the remaining dependecies lib and include files (refered henceforth as `$LIBS`).
+This directory should have a `lib` and `include` subfolders with the corresponding `.lib` and headers respectively.
+
+#### Zdepth
+
+Clone Zdepth repo
+
+```
+git clone https://github.com/catid/Zdepth.git
+```
+
+Open CMakeLists file in VS and build accorcing to your desired profile (x86 or x64; Debug or Release).
+
+If you did not specify an install dir during the CMake configuration, copy the `Zdepth\include` and output lib folders (e.g. `ZDepth\out\*`) to `$LIBS`.
+
+#### Azure Kinect Body Tracking SDK (optional)
+
+Install Azure Body Tracker SDK from the instructions available [here](https://www.microsoft.com/en-us/download/details.aspx?id=100942).
+
+Copy the SDK include and lib files from the SDK install list to `$LIBS`, or add the SDK path to SSP CMakeLists (see below)
+
+#### Building Sensor Stream Pipe
+
+Clone the SSP repo
+
+
+```
+git clone git@github.com:moetsi/Sensor-Stream-Pipe.git
+```
+
+Due to the diferences in the build process, the Windows CMake file is named CMakeListsWindows.txt at the root of the SSP repo.
+
+Thus, you shoud delete CMakeLists.txt and rename CMakeListsWindows.txt to CMakeLists.txt.
+
+Open CMakeLists.txt in VS.
+
+Replace/Add the include ("C://Users//Andre//source//repos//vcpkg//installed//x64-windows//include") and link paths ("C://Users//Andre//source//repos//vcpkg//installed//x64-windows//lib") at the top of the file with your `$LIBS` paths
+
+```
+include_directories("C://Users//Andre//source//repos//vcpkg//installed//x64-windows//include")
+link_directories("C://Users//Andre//source//repos//vcpkg//installed//x64-windows//lib")
+```
+
+You can also add your `vcpkg//installed//` dir to the include and link paths.
+
+After replacing the paths, set the desired compile options (SSP_WITH_KINECT_SUPPORT, SSP_WITH_K4A_BODYTRACK, ...), regenerate CMakeCache and build the project.
+
+#### Linking errors?
+
+
+if you have linking errors (missing .lib files), try replacing the short lib name with the full lib path in CMake: 
+"libzmq" -> "C:/Users/Andre/source/repos/vcpkg/installed/x64-windows/lib/libzmq.lib"

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ By taking data processing off device, you will be able to run far more powerful 
 
 ### Installation
 
-The following steps were tested on Ubuntu 18.04. Installing on other recent Linux distributions should be pretty similar, but please check the installation instructions for OpenCV and Kinect DK on your respective platform first. 
+SSP installation was tested on Ubuntu 18.04. Installing on other recent Linux distributions should be pretty similar, but please check the installation instructions for OpenCV and Kinect DK on your respective platform first. 
 
-Installation instructions for Windows should be ready soon.
+Installation instructions for Windows 10 are available on the [ INSTALL ](https://github.com/moetsi/Sensor-Stream-Pipe/blob/master/INSTALL.md) file.
 
 If you encounter any problems or have any suggestions, please let us know by emailing [contact@moetsi.com](mailto:contact@moetsi.com) or post on our [forum](https://moetsi.com/pages/community).
 

--- a/clients/ssp_client_k4a.cc
+++ b/clients/ssp_client_k4a.cc
@@ -7,6 +7,8 @@
 #include <thread>
 
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 #include <io.h>
 #else
 #include <unistd.h>

--- a/clients/ssp_client_k4a.cc
+++ b/clients/ssp_client_k4a.cc
@@ -5,7 +5,12 @@
 #include <chrono>
 #include <iostream>
 #include <thread>
+
+#ifdef _WIN32
+#include <io.h>
+#else
 #include <unistd.h>
+#endif 
 
 #include <k4a/k4a.h>
 #include <opencv2/imgproc.hpp>

--- a/clients/ssp_client_opencv.cc
+++ b/clients/ssp_client_opencv.cc
@@ -5,7 +5,12 @@
 #include <chrono>
 #include <iostream>
 #include <thread>
+
+#ifdef _WIN32
+#include <io.h>
+#else
 #include <unistd.h>
+#endif 
 
 #include <opencv2/imgproc.hpp>
 #include <zmq.hpp>

--- a/clients/ssp_client_pointcloud.cc
+++ b/clients/ssp_client_pointcloud.cc
@@ -7,6 +7,8 @@
 #include <thread>
 
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 #include <io.h>
 #else
 #include <unistd.h>

--- a/clients/ssp_client_pointcloud.cc
+++ b/clients/ssp_client_pointcloud.cc
@@ -5,7 +5,12 @@
 #include <chrono>
 #include <iostream>
 #include <thread>
+
+#ifdef _WIN32
+#include <io.h>
+#else
 #include <unistd.h>
+#endif 
 
 #include <k4a/k4a.h>
 #include <opencv2/imgproc.hpp>

--- a/clients/ssp_client_template.cc
+++ b/clients/ssp_client_template.cc
@@ -5,7 +5,12 @@
 #include <chrono>
 #include <iostream>
 #include <thread>
+
+#ifdef _WIN32
+#include <io.h>
+#else
 #include <unistd.h>
+#endif 
 
 #include <opencv2/imgproc.hpp>
 #include <zmq.hpp>

--- a/encoders/libav_encoder.cc
+++ b/encoders/libav_encoder.cc
@@ -236,7 +236,7 @@ void LibAvEncoder::Encode() {
 void LibAvEncoder::Init(std::shared_ptr<FrameStruct> &fs) {
   int ret;
 
-  spdlog::info("Codec information:\n {}", codec_parameters_);
+  //spdlog::info("Codec information:\n {}", codec_parameters_);
 
   av_codec_ =
       std::unique_ptr<AVCodec, AVCodecDeleter>(avcodec_find_encoder_by_name(

--- a/encoders/libav_encoder.cc
+++ b/encoders/libav_encoder.cc
@@ -283,8 +283,10 @@ void LibAvEncoder::Init(std::shared_ptr<FrameStruct> &fs) {
   av_codec_context_->width = width;
   av_codec_context_->height = height;
   /* frames per second */
-  av_codec_context_->time_base = (AVRational){1, (int)fps_};
-  av_codec_context_->framerate = (AVRational){(int)fps_, 1};
+  av_codec_context_->time_base.num = 1;
+  av_codec_context_->time_base.den = (int)fps_;
+  av_codec_context_->framerate.num = 1;
+  av_codec_context_->framerate.den = (int)fps_;
   av_codec_context_->gop_size = 0;
 
   av_codec_context_->bit_rate_tolerance = 0;

--- a/readers/video_file_reader.h
+++ b/readers/video_file_reader.h
@@ -8,6 +8,11 @@
 #include <iostream>
 #include <vector>
 
+#ifdef _WIN32
+#include <windows.h>
+#define ushort u_short
+#endif
+
 #include "../utils/logger.h"
 
 extern "C" {

--- a/servers/ssp_server.cc
+++ b/servers/ssp_server.cc
@@ -24,6 +24,7 @@
 #include "../encoders/null_encoder.h"
 #include "../encoders/zdepth_encoder.h"
 #include "../readers/video_file_reader.h"
+#include "../readers/multi_image_reader.h"
 
 #ifdef SSP_WITH_NVPIPE_SUPPORT
 #include "../encoders/nv_encoder.h"
@@ -31,7 +32,6 @@
 
 #ifdef SSP_WITH_KINECT_SUPPORT
 #include "../readers/kinect_reader.h"
-#include "../readers/multi_image_reader.h"
 #include "../utils/kinect_utils.h"
 #endif
 

--- a/servers/ssp_server.cc
+++ b/servers/ssp_server.cc
@@ -2,7 +2,12 @@
 // Created by amourao on 26-06-2019.
 //
 
+#ifdef _WIN32
+#include <io.h>
+#include <windows.h>
+#else
 #include <unistd.h>
+#endif
 
 #include "../utils/logger.h"
 

--- a/testers/ssp_tester.cc
+++ b/testers/ssp_tester.cc
@@ -31,6 +31,7 @@ extern "C" {
 #include "../encoders/null_encoder.h"
 #include "../encoders/zdepth_encoder.h"
 #include "../readers/video_file_reader.h"
+#include "../readers/multi_image_reader.h"
 #include "../utils/image_converter.h"
 #include "../utils/similarity_measures.h"
 #include "../utils/utils.h"
@@ -43,9 +44,10 @@ extern "C" {
 
 #ifdef SSP_WITH_KINECT_SUPPORT
 #include "../readers/kinect_reader.h"
-#include "../readers/multi_image_reader.h"
 #include "../utils/kinect_utils.h"
 #endif
+
+
 
 int main(int argc, char *argv[]) {
 

--- a/testers/ssp_tester.cc
+++ b/testers/ssp_tester.cc
@@ -5,7 +5,12 @@
 #include <chrono>
 #include <iostream>
 #include <thread>
+#ifdef _WIN32
+#include <io.h>
+#define ushort u_short
+#else
 #include <unistd.h>
+#endif 
 
 extern "C" {
 #include <libavcodec/avcodec.h>

--- a/utils/kinect_utils.h
+++ b/utils/kinect_utils.h
@@ -5,8 +5,12 @@
 #pragma once
 
 #include <iostream>
-#include <k4a/k4a.h>
+#include <k4a/k4a.hpp>
+
+#if (SSP_WITH_K4A_BODYTRACK)
 #include <k4abt.hpp>
+#endif
+
 #include <yaml-cpp/yaml.h>
 
 #include "../decoders/idecoder.h"

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -23,7 +23,14 @@ void SetupLogging(YAML::Node &general_parameters);
 void SetupLogging(std::string &level, std::string &file);
 
 #undef av_err2str
+
+#ifdef _WIN32
+#define av_err2str(errnum)                                                     \
+  av_make_error_string((char *)_malloca(AV_ERROR_MAX_STRING_SIZE),             \
+                       AV_ERROR_MAX_STRING_SIZE, errnum)
+#else
 #define av_err2str(errnum)                                                     \
   av_make_error_string((char *)__builtin_alloca(AV_ERROR_MAX_STRING_SIZE),     \
                        AV_ERROR_MAX_STRING_SIZE, errnum)
+#endif
 

--- a/utils/video_utils.h
+++ b/utils/video_utils.h
@@ -9,7 +9,12 @@
 #include <stdlib.h>
 #include <string>
 #include <thread>
+
+#ifdef _WIN32
+#include <io.h>
+#else
 #include <unistd.h>
+#endif 
 
 extern "C" {
 #include <libavcodec/avcodec.h>


### PR DESCRIPTION
Hi! I don't know what your status on windows builds is because your readme says "Windows build instructions coming soon", but I went ahead and built it for Windows myself using CMake and Visual Studio 2019.

For CMakeLists.txt I just had to remove the compiler flags that are only applicable to gcc.
Most of the commit is just swapping header files for windows-specific ones.

Also the 'ushort' type wasn't available for me.
I don't know whether u_short is available for gcc/linux etc. so I just wrapped a redefinition in the windows preprocessor directive, too.

After these changes I can then compile the project fine in Visual Studio 2019 after running:
`cmake .. -G"Visual Studio 16 2019" -DSSP_WITH_KINECT_SUPPORT=ON.....`

I did need to manually point to the proper lib and include directory locations in the project properties in VS.