### PR TITLE
Use polling to check NetworkReader has new frame

### DIFF
--- a/readers/network_reader.cc
+++ b/readers/network_reader.cc
@@ -16,9 +16,11 @@ NetworkReader::NetworkReader(int port) {
 void NetworkReader::init() {
   context_ = std::unique_ptr<zmq::context_t>(new zmq::context_t(1));
   socket_ = std::unique_ptr<zmq::socket_t>(new zmq::socket_t(*context_, ZMQ_PULL));
+#ifdef SSP_WITH_ZMQ_POLLING
   poller_.add(zmq::socket_ref(zmq::from_handle, socket_.get()->handle()),
       zmq::event_flags::pollin);
 
+#endif
   socket_->bind("tcp://*:" + std::to_string(port_));
 }
 
@@ -27,10 +29,14 @@ NetworkReader::~NetworkReader() {
 }
 
 bool NetworkReader::HasNextFrame() {
+#ifdef SSP_WITH_ZMQ_POLLING
     std::vector<zmq::poller_event<>> poller_ev(1);
     const auto recv = poller_.wait_all(poller_ev, std::chrono::milliseconds(POLL_TIMEOUT_MS));
     if (recv <= 0) return false;
     else return true;
+#else
+    return true;
+#endif
 }
 
 void NetworkReader::NextFrame() {

--- a/readers/network_reader.h
+++ b/readers/network_reader.h
@@ -9,6 +9,8 @@
 #include "../structs/frame_struct.hpp"
 #include "ireader.h"
 
+#define POLL_TIMEOUT_MS 500
+
 class NetworkReader {
 
 private:
@@ -25,6 +27,8 @@ private:
   int port_;
   std::unique_ptr<zmq::context_t> context_;
   std::unique_ptr<zmq::socket_t> socket_;
+
+  zmq::poller_t<> poller_;
 
 public:
   NetworkReader(int port);

--- a/readers/network_reader.h
+++ b/readers/network_reader.h
@@ -28,7 +28,9 @@ private:
   std::unique_ptr<zmq::context_t> context_;
   std::unique_ptr<zmq::socket_t> socket_;
 
+#ifdef SSP_WITH_ZMQ_POLLING
   zmq::poller_t<> poller_;
+#endif
 
 public:
   NetworkReader(int port);


### PR DESCRIPTION
Not sure if this is in your interest to merge or not, but I noticed that `NetworkReader::HasNextFrame()` has not been implemented in master... it just always returns true.

For the client I am building, it was necessary that I implemented this properly because of the blocking nature of `NetworkReader::NextFrame()`. I cannot just call this every frame and have the thread block, so first I check `HasNextFrame()` and only call `NextFrame()` if it returns true.

I say I'm not sure if my solution is in your interest to merge because it uses the **draft API** of zeromq. That being said, this particular polling API I am using has not changed in years....

Both zeromq and cppzmq need to be built with the draft api flags to enable this.

My solution is to just create a `zmq::poller` which simply checks if a frame has arrived.
The polling timeout before the function returns false is set with `POLL_TIMEOUT_MS`.