### PR TITLE
New feature to interface with Unity's ARFoundation

### DIFF
--- a/3rdparty/build_mac_dep.sh
+++ b/3rdparty/build_mac_dep.sh
@@ -28,8 +28,7 @@ function build_ffmpeg {
         --disable-static \
         --enable-shared \
         --enable-rpath \
-        --disable-programs \
-        --disable-ffmpeg \
+        --enable-ffmpeg \
         --disable-ffplay \
         --disable-ffprobe \
         --disable-securetransport

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,9 @@ target_link_libraries(ssp_plugin ssp)
 
 if (IOS)
   # Pack all the needed libraries for Unity3D iOS usage
+  # Usage:
+  # cmake --build . --config Release --target unity
+  # mv ssp_plugin_unity ~/UnityProject/Assets/Plugins/iOS
   add_custom_target(unity
           ${CMAKE_SOURCE_DIR}/cmake/package_for_unity.sh
           DEPENDS ssp_plugin)

--- a/readers/iphone_reader.mm
+++ b/readers/iphone_reader.mm
@@ -22,8 +22,23 @@ using namespace std;
   @public CVPixelBufferRef _depthBuffer;
   @public CVPixelBufferRef _confidenceBuffer;
   @public unsigned long _timestamp;
+  @private id<ARSessionDelegate> _parent;
 }
 @end
+
+static id<ARSessionDelegate> gSession = nil;
+
+struct UnityXRNativeSessionPtr
+{
+ int version;
+ void* session;
+};
+
+extern "C" void use_session(void* session)
+{
+    auto data = static_cast<UnityXRNativeSessionPtr*>(session);
+    gSession = (__bridge id<ARSessionDelegate>)(data->session);
+}
 
 @implementation SessionDelegate
 
@@ -38,6 +53,7 @@ using namespace std;
       _depthBuffer = nil;
       _confidenceBuffer = nil;
       _timestamp = 0;
+      _parent = gSession;
     }
     
     return self;

--- a/readers/iphone_reader.mm
+++ b/readers/iphone_reader.mm
@@ -171,13 +171,12 @@ iPhoneReader::iPhoneReader()
     pImpl->fps = 60;
     
     if (@available(iOS 11.3, *))
-      if (configuration)
         pImpl->fps = (unsigned int)configuration.videoFormat.framesPerSecond;
     
     // Depth is only supported on iOS 14 and above
     if (@available(iOS 14.0, *))
     {
-      if ([ARWorldTrackingConfiguration supportsFrameSemantics:ARFrameSemanticSceneDepth])
+      if ([ARWorldTrackingConfiguration supportsFrameSemantics:ARFrameSemanticSceneDepth] && configuration)
       {
         configuration.frameSemantics = ARFrameSemanticSceneDepth;
         spdlog::debug("Adding SceneDepth to configuration");


### PR DESCRIPTION
Add a `use_session` function to hook into ARSession started by Unity